### PR TITLE
Add "this." prefix in setter function to allow properties with name "value"

### DIFF
--- a/kotlin-builder-example-usage/src/main/kotlin/com/thinkinglogic/example/SimpleDataClass.kt
+++ b/kotlin-builder-example-usage/src/main/kotlin/com/thinkinglogic/example/SimpleDataClass.kt
@@ -11,6 +11,7 @@ data class SimpleDataClass(
         val notNullLong: Long,
         val nullableLong: Long?,
         val date: LocalDate,
+        val value: String,
         @DefaultValue("withDefaultValue") val stringWithDefault: String = "withDefaultValue",
         @DefaultValue("LocalDate.MIN") val defaultDate: LocalDate = LocalDate.MIN
 ) {

--- a/kotlin-builder-example-usage/src/test/java/com/thinkinglogic/example/SimpleDataClassJavaTest.java
+++ b/kotlin-builder-example-usage/src/test/java/com/thinkinglogic/example/SimpleDataClassJavaTest.java
@@ -32,6 +32,7 @@ public class SimpleDataClassJavaTest {
                 .notNullString("Foo")
                 .nullableString("Bar")
                 .notNullLong(123L)
+                .value("valueProperty")
                 .build();
 
         // when

--- a/kotlin-builder-example-usage/src/test/kotlin/com/thinkinglogic/example/SimpleDataClassTest.kt
+++ b/kotlin-builder-example-usage/src/test/kotlin/com/thinkinglogic/example/SimpleDataClassTest.kt
@@ -19,7 +19,8 @@ internal class SimpleDataClassTest {
                 nullableString = null,
                 notNullLong = 123,
                 nullableLong = 345,
-                date = LocalDate.now()
+                date = LocalDate.now(),
+                value = "valueProperty"
         )
 
         // when
@@ -28,6 +29,7 @@ internal class SimpleDataClassTest {
                 .notNullLong(expected.notNullLong)
                 .nullableLong(expected.nullableLong)
                 .date(expected.date)
+                .value(expected.value)
                 .stringWithDefault(expected.stringWithDefault)
                 .defaultDate(expected.defaultDate)
                 .build()
@@ -44,7 +46,8 @@ internal class SimpleDataClassTest {
                 nullableString = null,
                 notNullLong = 123,
                 nullableLong = 345,
-                date = LocalDate.now()
+                date = LocalDate.now(),
+                value = "valueProperty"
         )
 
         // when
@@ -53,6 +56,7 @@ internal class SimpleDataClassTest {
                 .notNullLong(expected.notNullLong)
                 .nullableLong(expected.nullableLong)
                 .date(expected.date)
+                .value(expected.value)
                 .build()
 
         // then
@@ -67,7 +71,8 @@ internal class SimpleDataClassTest {
                 nullableString = null,
                 notNullLong = 123,
                 nullableLong = 345,
-                date = LocalDate.now()
+                date = LocalDate.now(),
+                value = "valueProperty"
         )
 
         // when
@@ -86,7 +91,8 @@ internal class SimpleDataClassTest {
                 nullableString = null,
                 notNullLong = 123,
                 nullableLong = 345,
-                date = LocalDate.now()
+                date = LocalDate.now(),
+                value = "valueProperty"
         )
         val newStringValue = "New value"
 

--- a/kotlin-builder-processor/src/main/kotlin/com/thinkinglogic/builder/processor/BuilderProcessor.kt
+++ b/kotlin-builder-processor/src/main/kotlin/com/thinkinglogic/builder/processor/BuilderProcessor.kt
@@ -216,7 +216,7 @@ class BuilderProcessor : AbstractProcessor() {
         return FunSpec.builder(simpleName.toString())
                 .addParameter(ParameterSpec.builder("value", parameterClass).build())
                 .returns(builder)
-                .addCode("return apply·{ $simpleName·=·value }\n")
+                .addCode("return apply·{ this.$simpleName·=·value }\n")
                 .build()
     }
 


### PR DESCRIPTION
Fix issue #6 - Compilation of generated builder fails if class has a property named "value"